### PR TITLE
Km/pm 14863/allow unlock on list

### DIFF
--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -122,6 +122,7 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
         match r.read_byte() {
             Ok(REQUEST_IDENTITIES) => {
                 let agent = self.agent.take().ok_or(SSHAgentError::AgentFailure)?;
+                self.agent = Some(agent.clone());
                 if !agent.can_list().await {
                     writebuf.push(msg::FAILURE);
                 } else {

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -124,18 +124,17 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
                 let agent = self.agent.take().ok_or(SSHAgentError::AgentFailure)?;
                 if !agent.can_list().await {
                     writebuf.push(msg::FAILURE);
-                    return Ok(());
-                }
-
-                if let Ok(keys) = self.keys.0.read() {
-                    writebuf.push(msg::IDENTITIES_ANSWER);
-                    writebuf.push_u32_be(keys.len() as u32);
-                    for (public_key_bytes, key) in keys.iter() {
-                        writebuf.extend_ssh_string(public_key_bytes);
-                        writebuf.extend_ssh_string(key.name.as_bytes());
-                    }
                 } else {
-                    writebuf.push(msg::FAILURE)
+                    if let Ok(keys) = self.keys.0.read() {
+                        writebuf.push(msg::IDENTITIES_ANSWER);
+                        writebuf.push_u32_be(keys.len() as u32);
+                        for (public_key_bytes, key) in keys.iter() {
+                            writebuf.extend_ssh_string(public_key_bytes);
+                            writebuf.extend_ssh_string(key.name.as_bytes());
+                        }
+                    } else {
+                        writebuf.push(msg::FAILURE)
+                    }
                 }
             }
             Ok(SIGN_REQUEST) => {


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-14863
https://github.com/bitwarden/clients/pull/11994

Extend the ssh agent in order to allow consumers implementing the trait to provide an implementation that can determine whether listing keys is allowed (and do things like unlock the bitwarden vault in order to be able to list).