### PR TITLE
removing ubuntu-latest in favor of specified version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tagged-release:
     name: "Tagged Release"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
Change all occurrences of ubuntu-latest in any active (non-archived) repositories to ubuntu-24.04 owned by BRE.