### PR TITLE
Pass signing data to agent implementation and provide forwarding information

### DIFF
--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -176,8 +176,7 @@ impl<
                     let _hostkey = r.read_string()?;
                     let _session_identifier = r.read_string()?;
                     let _signature = r.read_string()?;
-                    let is_forwarding = r.read_byte()?;
-                    let is_forwarding = is_forwarding == 1;
+                    let is_forwarding = r.read_byte()? == 1;
                     let agent = self.agent.take().ok_or(SSHAgentError::AgentFailure)?;
                     agent
                         .set_is_forwarding(is_forwarding, &self.connection_info)

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -212,9 +212,7 @@ impl<
 
         let data = r.read_string()?;
 
-        let ok = agent
-            .confirm(key.clone(), data, &self.connection_info)
-            .await;
+        let ok = agent.confirm(key, data, &self.connection_info).await;
         if !ok {
             return Ok((agent, false));
         }

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -144,17 +144,15 @@ impl<
                 self.agent = Some(agent.clone());
                 if !agent.can_list(&self.connection_info).await {
                     writebuf.push(msg::FAILURE);
-                } else {
-                    if let Ok(keys) = self.keys.0.read() {
-                        writebuf.push(msg::IDENTITIES_ANSWER);
-                        writebuf.push_u32_be(keys.len() as u32);
-                        for (public_key_bytes, key) in keys.iter() {
-                            writebuf.extend_ssh_string(public_key_bytes);
-                            writebuf.extend_ssh_string(key.name.as_bytes());
-                        }
-                    } else {
-                        writebuf.push(msg::FAILURE)
+                } else if let Ok(keys) = self.keys.0.read() {
+                    writebuf.push(msg::IDENTITIES_ANSWER);
+                    writebuf.push_u32_be(keys.len() as u32);
+                    for (public_key_bytes, key) in keys.iter() {
+                        writebuf.extend_ssh_string(public_key_bytes);
+                        writebuf.extend_ssh_string(key.name.as_bytes());
                     }
+                } else {
+                    writebuf.push(msg::FAILURE)
                 }
             }
             Ok(SIGN_REQUEST) => {
@@ -168,7 +166,7 @@ impl<
                     writebuf.push(msg::FAILURE)
                 }
             }
-            Ok(EXTENSION) => {
+            Ok(_EXTENSION) => {
                 let extension_name = r.read_string()?;
                 let extension_name = String::from_utf8(extension_name.to_vec())
                     .map_err(|_| SSHAgentError::AgentFailure)?;

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 
-use crate::msg;
+use crate::msg::{self, EXTENSION};
 use anyhow::Error;
 
 use super::msg::{REQUEST_IDENTITIES, SIGN_REQUEST};
@@ -166,7 +166,7 @@ impl<
                     writebuf.push(msg::FAILURE)
                 }
             }
-            Ok(_EXTENSION) => {
+            Ok(EXTENSION) => {
                 let extension_name = r.read_string()?;
                 let extension_name = String::from_utf8(extension_name.to_vec())
                     .map_err(|_| SSHAgentError::AgentFailure)?;


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-15934
https://bitwarden.atlassian.net/browse/PM-15956
https://bitwarden.atlassian.net/browse/PM-15964
https://github.com/bitwarden/clients/pull/12371

Pass signing data to the implementation of the agent so it can make decisions based on the content. Further, use the EXTENSION for agent forwarding to track whether a connection is coming via agent forwarding.
