### PR TITLE
PM-16092: Note where the msg.rs constants are originally from

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,3 +1,9 @@
+/*
+    These constants come from:
+
+    https://github.com/openssh/openssh-portable/blob/master/authfd.h
+*/
+
 pub const FAILURE: u8 = 5;
 pub const SUCCESS: u8 = 6;
 pub const IDENTITIES_ANSWER: u8 = 12;


### PR DESCRIPTION
Super small ticket / PR just to note where the `msg.rs` constants originally come from. Please feel free to correct me here as I'm brand new to this repo.