### PR TITLE
[Beeep] Add session-bind extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,16 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 byteorder = "1.5.0"
+ecdsa = { version = "0.16.9", features = ["verifying"] }
+ed25519-dalek = { version = "2.1.1", features = ["signature"] }
 futures = "0.3.30"
+p256 = "0.13.2"
+p384 = "0.13.1"
+p521 = "0.13.3"
+rsa = "0.9.6"
 russh-cryptovec = "0.7.3"
 ssh-encoding = "0.2.0"
-ssh-key = { version = "0.6.6", default-features = false, features = ["encryption", "ed25519", "rsa", "getrandom"] }
+ssh-key = { version = "0.6.6", default-features = false, features = ["encryption", "ed25519", "rsa", "getrandom", "ecdsa"] }
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["io-util", "macros", "rt"] }
 tokio-util = "0.7.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod encoding;
 pub mod msg;
+pub mod session_bind;
 pub mod ssh_agent;

--- a/src/session_bind.rs
+++ b/src/session_bind.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use anyhow::Error;
 use rsa::{
-    sha2::{self, Digest},
-    signature, BigUint, Pkcs1v15Sign,
+    sha2::{self, Digest}, BigUint, Pkcs1v15Sign,
 };
 use russh_cryptovec::CryptoVec;
 use ssh_key::{
@@ -68,7 +67,7 @@ fn verify_rsa_signature(
             .verify(
                 Pkcs1v15Sign::new::<sha2::Sha256>(),
                 sha2::Sha256::digest(session_identifier).as_slice(),
-                &signature,
+                signature,
             )
             .map_err(Into::into)
     } else if alg == "rsa-sha2-512" {
@@ -76,7 +75,7 @@ fn verify_rsa_signature(
             .verify(
                 Pkcs1v15Sign::new::<sha2::Sha512>(),
                 sha2::Sha512::digest(session_identifier).as_slice(),
-                &signature,
+                signature,
             )
             .map_err(Into::into)
     } else {

--- a/src/session_bind.rs
+++ b/src/session_bind.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use anyhow::Error;
 use rsa::{
-    sha2::{self, Digest}, BigUint, Pkcs1v15Sign,
+    sha2::{self, Digest},
+    BigUint, Pkcs1v15Sign,
 };
 use russh_cryptovec::CryptoVec;
 use ssh_key::{

--- a/src/session_bind.rs
+++ b/src/session_bind.rs
@@ -1,0 +1,167 @@
+//! This file implements the SSH session-bind protocol.
+//! https://raw.githubusercontent.com/openssh/openssh-portable/refs/heads/master/PROTOCOL.agent
+
+use crate::{
+    encoding::{Position, Reader},
+    ssh_agent::Agent,
+};
+use anyhow::Error;
+use rsa::{
+    sha2::{self, Digest},
+    signature, BigUint, Pkcs1v15Sign,
+};
+use russh_cryptovec::CryptoVec;
+use ssh_key::{
+    public::{EcdsaPublicKey, Ed25519PublicKey, KeyData, RsaPublicKey},
+    EcdsaCurve,
+};
+
+use crate::ssh_agent::SSHAgentError;
+
+#[derive(Debug)]
+pub struct SessionBindInfo {
+    pub is_forwarding: bool,
+    pub host_key: Vec<u8>,
+    pub session_identifier: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum SessionBindResult {
+    Success(SessionBindInfo),
+    SignatureFailure,
+}
+
+fn verify_ed25519_signature(
+    key: &Ed25519PublicKey,
+    signature: &[u8],
+    _alg: String,
+    session_identifier: &[u8],
+) -> Result<(), Error> {
+    ed25519_dalek::VerifyingKey::from_bytes(&key.0)?
+        .verify_strict(
+            session_identifier,
+            &ed25519_dalek::Signature::from_slice(signature)?,
+        )
+        .map_err(Into::into)
+}
+
+fn verify_rsa_signature(
+    key: &RsaPublicKey,
+    signature: &[u8],
+    alg: String,
+    session_identifier: &[u8],
+) -> Result<(), Error> {
+    let n = key
+        .n
+        .as_positive_bytes()
+        .map(BigUint::from_bytes_be)
+        .ok_or(anyhow::anyhow!("Failed to parse RSA modulus"))?;
+    let e = key
+        .e
+        .as_positive_bytes()
+        .map(BigUint::from_bytes_be)
+        .ok_or(anyhow::anyhow!("Failed to parse RSA exponent"))?;
+    let verifying_key = rsa::RsaPublicKey::new(n, e)?;
+
+    if alg == "rsa-sha2-256" {
+        verifying_key
+            .verify(
+                Pkcs1v15Sign::new::<sha2::Sha256>(),
+                sha2::Sha256::digest(session_identifier).as_slice(),
+                &signature,
+            )
+            .map_err(Into::into)
+    } else if alg == "rsa-sha2-512" {
+        verifying_key
+            .verify(
+                Pkcs1v15Sign::new::<sha2::Sha512>(),
+                sha2::Sha512::digest(session_identifier).as_slice(),
+                &signature,
+            )
+            .map_err(Into::into)
+    } else {
+        Err(SSHAgentError::AgentFailure.into())
+    }
+}
+
+fn verify_ecdsa_signature(
+    key: &EcdsaPublicKey,
+    signature: &[u8],
+    _alg: String,
+    session_identifier: &[u8],
+) -> Result<(), Error> {
+    match key.curve() {
+        EcdsaCurve::NistP256 => {
+            use p256::ecdsa::signature::Verifier;
+            p256::ecdsa::VerifyingKey::from_sec1_bytes(key.as_sec1_bytes())?.verify(
+                session_identifier,
+                &p256::ecdsa::Signature::from_slice(signature)?,
+            )
+        }
+        EcdsaCurve::NistP384 => {
+            use p384::ecdsa::signature::Verifier;
+            p384::ecdsa::VerifyingKey::from_sec1_bytes(key.as_sec1_bytes())?.verify(
+                session_identifier,
+                &p384::ecdsa::Signature::from_slice(signature)?,
+            )
+        }
+        EcdsaCurve::NistP521 => {
+            use p521::ecdsa::signature::Verifier;
+            p521::ecdsa::VerifyingKey::from_sec1_bytes(key.as_sec1_bytes())?.verify(
+                session_identifier,
+                &p521::ecdsa::Signature::from_slice(signature)?,
+            )
+        }
+    }
+    .map_err(Into::into)
+}
+
+pub(crate) async fn respond_extension_session_bind<
+    'a,
+    A: Agent<I> + Send + Sync + 'static,
+    I: Clone,
+>(
+    agent: &mut A,
+    r: &mut Position<'a>,
+    connection_info: I,
+) -> Result<(), Error> {
+    let hostkey_bytes = r.read_string()?;
+    let hostkey =
+        ssh_key::PublicKey::from_bytes(hostkey_bytes).map_err(|_| SSHAgentError::AgentFailure)?;
+    let session_identifier = r.read_string()?;
+
+    let signature = CryptoVec::from_slice(r.read_string()?);
+    let mut signature = signature.reader(0);
+    let alg = String::from_utf8(signature.read_string()?.to_vec())
+        .map_err(|_| SSHAgentError::AgentFailure)?;
+    let signature = signature.read_string()?.to_vec();
+
+    let is_forwarding = r.read_byte()? == 1;
+
+    let signature_verified = match hostkey.key_data() {
+        KeyData::Ed25519(key) => verify_ed25519_signature(key, &signature, alg, session_identifier),
+        KeyData::Rsa(key) => verify_rsa_signature(key, &signature, alg, session_identifier),
+        KeyData::Ecdsa(key) => verify_ecdsa_signature(key, &signature, alg, session_identifier),
+        _ => Ok(()),
+    }
+    .is_ok();
+
+    if !signature_verified {
+        agent
+            .set_sessionbind_info(&SessionBindResult::SignatureFailure, &connection_info)
+            .await;
+        Err(SSHAgentError::SignatureVerificationFailed.into())
+    } else {
+        agent
+            .set_sessionbind_info(
+                &SessionBindResult::Success(SessionBindInfo {
+                    is_forwarding,
+                    host_key: hostkey_bytes.to_vec(),
+                    session_identifier: session_identifier.to_vec(),
+                }),
+                &connection_info,
+            )
+            .await;
+        Ok(())
+    }
+}

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -187,8 +187,9 @@ impl<
                         } else {
                             writebuf.push(msg::FAILURE);
                         }
+                    } else {
+                        writebuf.push(msg::SUCCESS);
                     }
-                    writebuf.push(msg::SUCCESS);
                 } else {
                     writebuf.push(msg::FAILURE);
                 }

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -5,8 +5,11 @@ use std::sync::{Arc, RwLock};
 use crate::encoding::{Encoding, Position, Reader};
 use byteorder::{BigEndian, ByteOrder};
 use futures::stream::{Stream, StreamExt};
+use rsa::sha2::Digest;
+use rsa::{sha2, BigUint, Pkcs1v15Sign};
 use russh_cryptovec::CryptoVec;
-use ssh_key::{HashAlg, SigningKey};
+use ssh_key::public::{EcdsaPublicKey, Ed25519PublicKey, KeyData, RsaPublicKey};
+use ssh_key::{EcdsaCurve, HashAlg, SigningKey};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
@@ -49,9 +52,11 @@ pub trait Agent<I>: Clone + Send + 'static {
         async { true }
     }
 
-    fn set_is_forwarding(
+    fn set_sessionbind_info(
         &self,
         _is_forwarding: bool,
+        _hostkey: &[u8],
+        _session_identifier: &[u8],
         _connection_info: &I,
     ) -> impl std::future::Future<Output = ()> + Send {
         async {}
@@ -173,13 +178,46 @@ impl<
 
                 // https://raw.githubusercontent.com/openssh/openssh-portable/refs/heads/master/PROTOCOL.agent
                 if extension_name == "session-bind@openssh.com" {
-                    let _hostkey = r.read_string()?;
-                    let _session_identifier = r.read_string()?;
-                    let _signature = r.read_string()?;
+                    let hostkey_bytes = r.read_string()?;
+                    let hostkey = ssh_key::PublicKey::from_bytes(&hostkey_bytes)
+                        .map_err(|_| SSHAgentError::AgentFailure)?;
+                    let session_identifier = r.read_string()?;
+
+                    let signature_bytes = r.read_string()?;
+                    let binding = CryptoVec::from_slice(&signature_bytes);
+                    let mut signature = binding.reader(0);
+                    let alg = String::from_utf8(signature.read_string()?.to_vec())
+                        .map_err(|_| SSHAgentError::AgentFailure)?;
+                    let signature = signature.read_string()?.to_vec();
+
                     let is_forwarding = r.read_byte()? == 1;
+
+                    let signature_verification = match hostkey.key_data() {
+                        KeyData::Ed25519(key) => {
+                            verify_ed25519_signature(key, &signature, alg, session_identifier)
+                        }
+                        KeyData::Rsa(key) => {
+                            verify_rsa_signature(key, &signature, alg, session_identifier)
+                        }
+                        KeyData::Ecdsa(key) => {
+                            verify_ecdsa_signature(key, &signature, alg, session_identifier)
+                        }
+                        _ => Ok(()),
+                    };
+                    println!("signature_verification {:?}", signature_verification);
+                    if !signature_verification.is_ok() {
+                        writebuf.push(msg::FAILURE);
+                        return Ok(());
+                    }
+
                     let agent = self.agent.take().ok_or(SSHAgentError::AgentFailure)?;
                     agent
-                        .set_is_forwarding(is_forwarding, &self.connection_info)
+                        .set_sessionbind_info(
+                            is_forwarding,
+                            hostkey_bytes,
+                            session_identifier,
+                            &self.connection_info,
+                        )
                         .await;
                     self.agent = Some(agent);
                     writebuf.push(msg::SUCCESS);
@@ -277,4 +315,93 @@ impl<
 pub enum SSHAgentError {
     #[error("Agent failure")]
     AgentFailure,
+}
+
+fn verify_ed25519_signature(
+    key: &Ed25519PublicKey,
+    signature: &[u8],
+    _alg: String,
+    session_identifier: &[u8],
+) -> Result<(), Error> {
+    ed25519_dalek::VerifyingKey::from_bytes(&key.0)?
+        .verify_strict(
+            session_identifier,
+            &ed25519_dalek::Signature::from_slice(signature)?,
+        )
+        .map_err(Into::into)
+}
+
+fn verify_rsa_signature(
+    key: &RsaPublicKey,
+    signature: &[u8],
+    alg: String,
+    session_identifier: &[u8],
+) -> Result<(), Error> {
+    let n = key
+        .n
+        .as_positive_bytes()
+        .map(BigUint::from_bytes_be)
+        .ok_or(anyhow::anyhow!("Failed to parse RSA modulus"))?;
+    let e = key
+        .e
+        .as_positive_bytes()
+        .map(BigUint::from_bytes_be)
+        .ok_or(anyhow::anyhow!("Failed to parse RSA exponent"))?;
+    let verifying_key = rsa::RsaPublicKey::new(n, e)?;
+    if alg == "rsa-sha2-256" {
+        verifying_key
+            .verify(
+                Pkcs1v15Sign::new::<sha2::Sha256>(),
+                sha2::Sha256::digest(session_identifier).as_slice(),
+                &signature,
+            )
+            .map_err(Into::into)
+    } else if alg == "rsa-sha2-512" {
+        verifying_key
+            .verify(
+                Pkcs1v15Sign::new::<sha2::Sha512>(),
+                sha2::Sha512::digest(session_identifier).as_slice(),
+                &signature,
+            )
+            .map_err(Into::into)
+    } else {
+        Err(SSHAgentError::AgentFailure.into())
+    }
+}
+
+fn verify_ecdsa_signature(
+    key: &EcdsaPublicKey,
+    signature: &[u8],
+    _alg: String,
+    session_identifier: &[u8],
+) -> Result<(), Error> {
+    match key.curve() {
+        EcdsaCurve::NistP256 => {
+            use p256::ecdsa::signature::Verifier;
+            p256::ecdsa::VerifyingKey::from_sec1_bytes(key.as_sec1_bytes())?
+                .verify(
+                    session_identifier,
+                    &p256::ecdsa::Signature::from_slice(signature)?,
+                )
+                .map_err(Into::into)
+        }
+        EcdsaCurve::NistP384 => {
+            use p384::ecdsa::signature::Verifier;
+            p384::ecdsa::VerifyingKey::from_sec1_bytes(key.as_sec1_bytes())?
+                .verify(
+                    session_identifier,
+                    &p384::ecdsa::Signature::from_slice(signature)?,
+                )
+                .map_err(Into::into)
+        }
+        EcdsaCurve::NistP521 => {
+            use p521::ecdsa::signature::Verifier;
+            p521::ecdsa::VerifyingKey::from_sec1_bytes(key.as_sec1_bytes())?
+                .verify(
+                    session_identifier,
+                    &p521::ecdsa::Signature::from_slice(signature)?,
+                )
+                .map_err(Into::into)
+        }
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

Client PR: https://github.com/bitwarden/clients/pull/14602

## 📔 Objective

Adds support for the openssh-session-bind extension, allowing host keys, of machines that are being connected to to be passed through to the agent.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
